### PR TITLE
bug fix

### DIFF
--- a/Assets/Scripts/BossInformation.cs
+++ b/Assets/Scripts/BossInformation.cs
@@ -44,4 +44,8 @@ public class BossInformation : MonoBehaviour
             bossShield.playShieldBreakAnimation();
         }
     }
+    public void setMinionCount(int count)
+    {
+        minionCount = count;
+    }
 }

--- a/Assets/Scripts/Enemy/Minion/MinionController.cs
+++ b/Assets/Scripts/Enemy/Minion/MinionController.cs
@@ -51,6 +51,7 @@ public class MinionController : MonoBehaviour
             StartCoroutine(moveToAnchor());
         }
         currentHealth = maxhealth;
+        healthBar.SetHealth((int)(currentHealth / maxhealth * 100f));
         burstTimer = burstDensity;
         return;
     }

--- a/Assets/Scripts/Enemy/Minion/MinionSpawnerController.cs
+++ b/Assets/Scripts/Enemy/Minion/MinionSpawnerController.cs
@@ -46,6 +46,8 @@ public class MinionSpawnerController : MonoBehaviour
         if(activeEntityInstances ==0) 
         {
             spawnWave();
+            BossInformation info = FindFirstObjectByType<BossInformation>();
+            info.setMinionCount(entityCount);
         }
     }
 }


### PR DESCRIPTION
Minion health now shows full when respawned.
Shield Now breaks when all minions are kill on respawn waves rather than the first minion.
